### PR TITLE
yaml.load -> yaml.safe_load

### DIFF
--- a/src/main/python/triforce/main.py
+++ b/src/main/python/triforce/main.py
@@ -133,7 +133,7 @@ def process_venvs(config_files):
     venvs = []
     for config_file in config_files:
         with open(config_file) as config_file_pointer:
-            config = yaml.load(config_file_pointer)
+            config = yaml.safe_load(config_file_pointer)
             for name, venv in config.items():
                 venvs.append(parse_venv(name, venv))
     return venvs


### PR DESCRIPTION
`yaml.load` is deprecated, this switches to `yaml.safe_load` instead.

Without this change, 
```
python3 -m venv test && source test/bin/activate && pip install triforce && triforce <some.triforce.config>
```
breaks.